### PR TITLE
[FIX] UserAdmin actually expects a 'name' to be present

### DIFF
--- a/authtools/admin.py
+++ b/authtools/admin.py
@@ -66,7 +66,7 @@ class StrippedNamedUserAdmin(StrippedUserAdmin):
     search_fields = ('email', 'name',)
 
 
-class UserAdmin(StrippedNamedUserAdmin):
+class UserAdmin(StrippedUserAdmin):
     fieldsets = (
         BASE_FIELDS,
         ADVANCED_PERMISSION_FIELDS,


### PR DESCRIPTION
Looks like a typo made UserAdmin and NamedUserAdmin behave the same. UserAdmin should inherit only from StrippedUserAdmin, so it can have no 'name'
