### PR TITLE
Added send_mail to AbstractEmailUser for consistency with Django's Abstr...

### DIFF
--- a/authtools/models.py
+++ b/authtools/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.core.mail import send_mail
 from django.db import models
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.utils.translation import ugettext_lazy as _
@@ -51,6 +52,11 @@ class AbstractEmailUser(AbstractBaseUser, PermissionsMixin):
     def get_short_name(self):
         return self.email
 
+    def email_user(self, subject, message, from_email=None, **kwargs):
+        """
+        Sends an email to this User.
+        """
+        send_mail(subject, message, from_email, [self.email], **kwargs)
 
 @python_2_unicode_compatible
 class AbstractNamedUser(AbstractEmailUser):

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -3,6 +3,7 @@ We're able to borrow most of django's auth view tests.
 
 """
 
+from django.core import mail
 from django.core.urlresolvers import reverse
 from django.contrib.sites.models import Site, RequestSite
 from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
@@ -462,3 +463,16 @@ class UserModelTest(TestCase):
                          "only check authuser's ordering")
     def test_default_ordering(self):
         self.assertSequenceEqual(['name', 'email'], User._meta.ordering)
+
+    def test_send_mail(self):
+        abstract_user = User(email='foo@bar.com')
+        abstract_user.email_user(subject="Subject here",
+            message="This is a message", from_email="from@domain.com")
+        # Test that one message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        # Verify that test email contains the correct attributes:
+        message = mail.outbox[0]
+        self.assertEqual(message.subject, "Subject here")
+        self.assertEqual(message.body, "This is a message")
+        self.assertEqual(message.from_email, "from@domain.com")
+        self.assertEqual(message.to, [abstract_user.email])


### PR DESCRIPTION
...actUser.

Since Django has the function, for smoother transitions from Django AbstractUser to the AbstractEmailUser.

The code is exactly as is in Django.

This solves one compatibility issue for instance in django-registration, which uses send_mail.
