### PR TITLE
Tests fail on Django 1.6

### DIFF
--- a/tests/manage.py
+++ b/tests/manage.py
@@ -10,4 +10,8 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
+    from django.contrib.auth.tests import custom_user
+    custom_user.AbstractUser._meta.local_many_to_many = []
+    custom_user.PermissionsMixin._meta.local_many_to_many = []
+
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
https://travis-ci.org/fusionbox/django-authtools/jobs/12636076#L186

This is due to https://github.com/django/django/commit/4a9bae0b39aebdedf38fcb760405c04b8216c508 and https://code.djangoproject.com/ticket/21164 and how we reuse Django's tests.
