### PR TITLE
Updating view to pass in correct http/https flag

### DIFF
--- a/authtools/views.py
+++ b/authtools/views.py
@@ -215,6 +215,7 @@ class PasswordResetView(CsrfProtectMixin, FormView):
             token_generator=self.token_generator,
             from_email=self.from_email,
             request=self.request,
+            use_https=self.request.is_secure()
         )
         return super(PasswordResetView, self).form_valid(form)
 


### PR DESCRIPTION
In the current implementation the flag isn't being passed into the form, so it's defaulting to http regardless of current request. This PR simply sets the flag correctly based on the current request setting.