### PR TITLE
Give PasswordChangeView WithNextUrlMixin

### DIFF
--- a/authtools/views.py
+++ b/authtools/views.py
@@ -163,7 +163,7 @@ logout_then_login = LogoutView.as_view(
 )
 
 
-class PasswordChangeView(LoginRequiredMixin, AuthDecoratorsMixin, FormView):
+class PasswordChangeView(LoginRequiredMixin, WithNextUrlMixin, AuthDecoratorsMixin, FormView):
     template_name = 'registration/password_change_form.html'
     form_class = PasswordChangeForm
     success_url = reverse_lazy('password_change_done')

--- a/docs/views.rst
+++ b/docs/views.rst
@@ -56,7 +56,8 @@ them after they reset their password.
     .. attribute:: success_url
 
         This replaces the ``post_change_redirect`` parameter present in the
-        built-in function.  Defaults to the 'password_change_done' view.
+        built-in function.  Uses the ``next`` URL parameter or defaults to the
+        'password_change_done' view.
 
 .. class:: PasswordChangeDoneView
 


### PR DESCRIPTION
This allows passing a `next` query parameter to control the redirection after changing the password. It doesn't change the behavior if `next` is not passed.