### PR TITLE
Convert test suite to use tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/.coverage
 tests/htmlcov/
 dist/
 build/
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
+sudo: false
 language: python
 python:
   - "2.7"
-  - "2.6"
-  - "3.3"
+cache:
+  directories:
+    - $HOME/.pip-cache/
 env:
-  - DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.5.x.zip
-  - DJANGO_PACKAGE=https://github.com/django/django/archive/stable/1.6.x.zip
+  - TOX_ENV=py26-dj15
+  - TOX_ENV=py26-dj16
+  - TOX_ENV=py27-dj15
+  - TOX_ENV=py27-dj16
+  - TOX_ENV=py33-dj15
+  - TOX_ENV=py33-dj16
 install:
-  - pip install -q $DJANGO_PACKAGE --use-mirrors
-  - python setup.py install
-script: make test
+  - pip install --upgrade pip
+  - pip install tox==1.8.0
+script:
+  - tox -e $TOX_ENV
+after_script:
+  - cat .tox/$TOX_ENV/log/*.log

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist=
+    py{26,27,33}-dj{15,16}
+
+[testenv]
+basepython=
+  py26: python2.6
+  py27: python2.7
+  py33: python3.3
+commands=
+  /usr/bin/env
+  make test
+deps=
+  dj15,dj16: South>=1.0.2
+  dj15: Django>=1.5,<1.6
+  dj16: Django>=1.6,<1.7
+whitelist_externals=
+  env
+  make


### PR DESCRIPTION
Very similar to what I did with the `django-widgy` test suite.  I figured this was a good step towards expanding test coverage to django 1.7.

Cute animal picture for your troubles.

![l_26fc8fa0-b950-11e1-a7c2-856fab900007](https://cloud.githubusercontent.com/assets/824194/6340662/a84b28dc-bb7e-11e4-91bf-c82edee1ca63.jpg)
