### PR TITLE
Create migrations for Django 1.7 and 1.8.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,13 @@ CHANGES
 1.2.1 (unreleased)
 ------------------
 
- - Create migrations for authtools.
+- Create migrations for authtools.
 
-   If updating from an older authtools, these migrations must be run on your apps::
+  If updating from an older authtools, these migrations must be run on your apps::
 
-     $ python manage.py migrate --fake authtools 0001_initial
+    $ python manage.py migrate --fake authtools 0001_initial
 
-     $ python manage.py migrate
+    $ python manage.py migrate
 
 
 1.2.0 (2015-04-02)
@@ -26,60 +26,60 @@ CHANGES
 1.1.0 (2015-02-24)
 ------------------
 
-  - PasswordChangeView now handles a ``next`` URL parameter (#24)
+- PasswordChangeView now handles a ``next`` URL parameter (#24)
 
 1.0.0 (released August 16, 2014)
 --------------------------------
 
-  - Add friendly_password_reset view and FriendlyPasswordResetForm (Antoine Catton, #18)
-  - **Bugfix** Allow LOGIN_REDIRECT_URL to be unicode (Alan Johnson, Gavin Wahl, Rocky Meza, #13)
-  - **Backwards Incompatible** Dropped support for Python 3.2
+- Add friendly_password_reset view and FriendlyPasswordResetForm (Antoine Catton, #18)
+- **Bugfix** Allow LOGIN_REDIRECT_URL to be unicode (Alan Johnson, Gavin Wahl, Rocky Meza, #13)
+- **Backwards Incompatible** Dropped support for Python 3.2
 
 0.2.2 (released July 21, 2014)
 ------------------------------
 
-  - Update safe urls in tests
-  - Give the ability to restrain which users can reset their password
-  - Add send_mail to AbstractEmailUser. (Jorge C. Leitão)
+- Update safe urls in tests
+- Give the ability to restrain which users can reset their password
+- Add send_mail to AbstractEmailUser. (Jorge C. Leitão)
 
 
 0.2.1
 -----
 
-  - Bugfix: UserAdmin was expecting a User with a `name` field.
+- Bugfix: UserAdmin was expecting a User with a `name` field.
 
 0.2.0
 -----
 
-  - Django 1.6 support.
+- Django 1.6 support.
 
-    Django 1.6 `broke backwards compatibility
-    <https://docs.djangoproject.com/en/dev/releases/1.6/#django-contrib-auth-password-reset-uses-base-64-encoding-of-user-pk>`_
-    of the ``password_reset_confirm`` view. Be sure to update any references to
-    this URL. Rather than using a separate view for each encoding, authtools uses
-    `a single view
-    <https://django-authtools.readthedocs.org/en/latest/views.html#authtools.views.PasswordResetConfirmView>`_
-    that works with both.
+  Django 1.6 `broke backwards compatibility
+  <https://docs.djangoproject.com/en/dev/releases/1.6/#django-contrib-auth-password-reset-uses-base-64-encoding-of-user-pk>`_
+  of the ``password_reset_confirm`` view. Be sure to update any references to
+  this URL. Rather than using a separate view for each encoding, authtools uses
+  `a single view
+  <https://django-authtools.readthedocs.org/en/latest/views.html#authtools.views.PasswordResetConfirmView>`_
+  that works with both.
 
-  - Bugfix: if LOGIN_URL was a URL name, it wasn't being reversed in the
-    PasswordResetConfirmView.
+- Bugfix: if LOGIN_URL was a URL name, it wasn't being reversed in the
+  PasswordResetConfirmView.
 
 0.1.2 (released July 01, 2013)
 ------------------------------
 
-  - Use ``prefetch_related`` in the
-    `UserChangeForm <https://django-authtools.readthedocs.org/en/latest/forms.html#authtools.forms.UserChangeForm>`_
-    to avoid doing hundreds of ``ContentType`` queries. The form from
-    Django has the same feature, it wasn't copied over correctly in our
-    original form.
+- Use ``prefetch_related`` in the
+  `UserChangeForm <https://django-authtools.readthedocs.org/en/latest/forms.html#authtools.forms.UserChangeForm>`_
+  to avoid doing hundreds of ``ContentType`` queries. The form from
+  Django has the same feature, it wasn't copied over correctly in our
+  original form.
 
 0.1.1 (released May 30, 2013)
 -----------------------------
 
 * some bugfixes:
 
-  - Call ``UserManager.normalize_email`` on an instance, not a class.
-  - ``authtools.models.User`` should inherit its parent's ``Meta``.
+- Call ``UserManager.normalize_email`` on an instance, not a class.
+- ``authtools.models.User`` should inherit its parent's ``Meta``.
 
 0.1.0 (released May 28, 2013)
 -----------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,13 @@ CHANGES
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+ - Create migrations for authtools.
+
+   If updating from an older authtools, these migrations must be run on your apps::
+
+     $ python manage.py migrate --fake authtools 0001_initial
+
+     $ python manage.py migrate
 
 
 1.2.0 (2015-04-02)

--- a/authtools/migrations/0001_initial.py
+++ b/authtools/migrations/0001_initial.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='User',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(default=django.utils.timezone.now, verbose_name='last login')),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('email', models.EmailField(unique=True, max_length=255, verbose_name='email address', db_index=True)),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active.  Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('name', models.CharField(max_length=255, verbose_name='name')),
+                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
+            ],
+            options={
+                'ordering': ['name', 'email'],
+                'abstract': False,
+                'verbose_name': 'user',
+                'swappable': 'AUTH_USER_MODEL',
+                'verbose_name_plural': 'users',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/authtools/migrations/0002_django18.py
+++ b/authtools/migrations/0002_django18.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('authtools', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='last_login',
+            field=models.DateTimeField(null=True, verbose_name='last login', blank=True),
+        ),
+    ]

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -14,6 +14,10 @@ Installation
 
         $ pip install -e git://github.com/fusionbox/django-authtools@master#egg=django-authtools-dev
 
+2.  Run the authtools migrations::
+
+        $ python manage.py migrate
+
 
 Quick Setup
 -----------


### PR DESCRIPTION
Authtools has no migrations but depends on contrib.auth which has
migrations.