### PR TITLE
Import tests from Django 1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/htmlcov/
 dist/
 build/
 .tox
+/django.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,10 @@ cache:
   directories:
     - $HOME/.pip-cache/
 env:
-  - TOX_ENV=py26-dj15
-  - TOX_ENV=py26-dj16
-  - TOX_ENV=py27-dj15
-  - TOX_ENV=py27-dj16
   - TOX_ENV=py27-dj17
-  - TOX_ENV=py33-dj15
-  - TOX_ENV=py33-dj16
   - TOX_ENV=py33-dj17
+  - TOX_ENV=py27-dj18
+  - TOX_ENV=py33-dj18
 install:
   - pip install --upgrade pip
   - pip install tox==1.8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
   directories:
     - $HOME/.pip-cache/
 env:
-  - TOX_ENV=py27-dj17
-  - TOX_ENV=py33-dj17
   - TOX_ENV=py27-dj18
   - TOX_ENV=py33-dj18
 install:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ TESTS=tests authtools
 SETTINGS=tests.sqlite_test_settings
 COVERAGE_COMMAND=
 
+DJANGO_TGZ=https://github.com/django/django/archive/1.8.4.tar.gz
+DJANGO_CHECKSUM=42c8f39e1542db11fa057be3da68b3126c3f639a76eb2ea8733faed0ae0f650d
+
 
 test: test-builtin test-authtools test-customuser
 
@@ -17,6 +20,15 @@ test-customuser:
 coverage:
 	+make test COVERAGE_COMMAND='coverage run --source=authtools --branch --parallel-mode'
 	cd tests && coverage combine && coverage html
+
+django.tar.gz: export TMP=$(shell mktemp)
+django.tar.gz:
+	wget "$(DJANGO_TGZ)" -O "$${TMP}"
+	echo "$(DJANGO_CHECKSUM) " "$${TMP}" | sha256sum -c
+	mv "$${TMP}" "$@"
+
+tests/auth_tests: django.tar.gz
+	tar -xf $< --strip-components=2 -C ./tests "django*/tests/auth_tests"
 
 docs:
 	cd docs && $(MAKE) html

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ DJANGO_CHECKSUM=42c8f39e1542db11fa057be3da68b3126c3f639a76eb2ea8733faed0ae0f650d
 
 test: test-builtin test-authtools test-customuser
 
-test-builtin:
+test-builtin: tests/auth_tests
 	cd tests && DJANGO_SETTINGS_MODULE=$(SETTINGS) $(COVERAGE_COMMAND) ./manage.py test --traceback $(TESTS) --verbosity=2
 
-test-authtools:
+test-authtools: tests/auth_tests
 	+AUTH_USER_MODEL='authtools.User' make test-builtin
 
-test-customuser:
+test-customuser: tests/auth_tests
 	+AUTH_USER_MODEL='tests.User' make test-builtin
 
 coverage:
@@ -28,7 +28,7 @@ django.tar.gz:
 	mv "$${TMP}" "$@"
 
 tests/auth_tests: django.tar.gz
-	tar -xf $< --strip-components=2 -C ./tests "django*/tests/auth_tests"
+	tar --wildcards -xf $< --strip-components=2 -C ./tests "django*/tests/auth_tests"
 
 docs:
 	cd docs && $(MAKE) html

--- a/authtools/forms.py
+++ b/authtools/forms.py
@@ -154,7 +154,7 @@ class AdminUserChangeForm(UserChangeForm):
             self.fields['password'].help_text = _(
                 "Raw passwords are not stored, so there is no way to see this"
                 " user's password, but you can change the password using"
-                " <a href=\"password/\">this form</a>.")
+                " <a href=\"../password/\">this form</a>.")
 
 
 class FriendlyPasswordResetForm(OldPasswordResetForm):

--- a/authtools/urls.py
+++ b/authtools/urls.py
@@ -1,28 +1,19 @@
-import django
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+
+from authtools import views
 
 
-urlpatterns = patterns('authtools.views',
-    url(r'^login/$', 'login', name='login'),
-    url(r'^logout/$', 'logout', name='logout'),
-    url(r'^password_change/$', 'password_change', name='password_change'),
-    url(r'^password_change/done/$', 'password_change_done', name='password_change_done'),
-    url(r'^password_reset/$', 'password_reset', name='password_reset'),
-    url(r'^password_reset/done/$', 'password_reset_done', name='password_reset_done'),
-    url(r'^reset/done/$', 'password_reset_complete', name='password_reset_complete'),
-)
-
-if django.VERSION < (1, 6):
-    urlpatterns += patterns('authtools.views',
-        url(r'^reset/(?P<uidb36>[0-9A-Za-z]{1,13})-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-            'password_reset_confirm',
-            name='password_reset_confirm'),
-    )
-else:
-    urlpatterns += patterns('authtools.views',
-        url(r'^reset/(?P<uidb36>[0-9A-Za-z]{1,13})-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-            'password_reset_confirm_uidb36'),
-        url(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-            'password_reset_confirm',
-            name='password_reset_confirm'),
-    )
+urlpatterns = [
+    url(r'^login/$', views.LoginView.as_view(), name='login'),
+    url(r'^logout/$', views.LogoutView.as_view(), name='logout'),
+    url(r'^password_change/$', views.PasswordChangeView.as_view(), name='password_change'),
+    url(r'^password_change/done/$', views.PasswordChangeDoneView.as_view(), name='password_change_done'),
+    url(r'^password_reset/$', views.PasswordResetView.as_view(), name='password_reset'),
+    url(r'^password_reset/done/$', views.PasswordResetDoneView.as_view(), name='password_reset_done'),
+    url(r'^reset/done/$', views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),
+    url(r'^reset/(?P<uidb36>[0-9A-Za-z]{1,13})-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        views.PasswordResetConfirmView.as_view()),
+    url(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+        views.PasswordResetConfirmView.as_view(),
+        name='password_reset_confirm'),
+]

--- a/authtools/views.py
+++ b/authtools/views.py
@@ -26,8 +26,6 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import FormView, TemplateView, RedirectView
 
-from authtools.forms import FriendlyPasswordResetForm
-
 
 User = get_user_model()
 
@@ -162,8 +160,6 @@ class LoginView(AuthDecoratorsMixin, WithCurrentSiteMixin, WithNextUrlMixin, For
         })
         return kwargs
 
-login = LoginView.as_view()
-
 
 class LogoutView(NeverCacheMixin, WithCurrentSiteMixin, WithNextUrlMixin, TemplateView, RedirectView):
     template_name = 'registration/logged_out.html'
@@ -176,11 +172,6 @@ class LogoutView(NeverCacheMixin, WithCurrentSiteMixin, WithNextUrlMixin, Templa
             return RedirectView.get(self, *args, **kwargs)
         else:
             return TemplateView.get(self, *args, **kwargs)
-
-logout = LogoutView.as_view()
-logout_then_login = LogoutView.as_view(
-    url=reverse_lazy('login')
-)
 
 
 class PasswordChangeView(LoginRequiredMixin, WithNextUrlMixin, AuthDecoratorsMixin, FormView):
@@ -200,21 +191,17 @@ class PasswordChangeView(LoginRequiredMixin, WithNextUrlMixin, AuthDecoratorsMix
         form.save()
         return super(PasswordChangeView, self).form_valid(form)
 
-password_change = PasswordChangeView.as_view()
-
 
 class PasswordChangeDoneView(LoginRequiredMixin, TemplateView):
     template_name = 'registration/password_change_done.html'
 
-password_change_done = PasswordChangeDoneView.as_view()
-
 
 # 4 views for password reset:
-# - password_reset sends the mail
-# - password_reset_done shows a success message for the above
-# - password_reset_confirm checks the link the user clicked and
+# - PasswordResetView sends the mail
+# - PasswordResetDoneView shows a success message for the above
+# - PasswordResetConfirmView checks the link the user clicked and
 #   prompts for a new password
-# - password_reset_complete shows a success message for the above
+# - PasswordResetCompleteView shows a success message for the above
 
 
 class PasswordResetView(CsrfProtectMixin, FormView):
@@ -241,16 +228,9 @@ class PasswordResetView(CsrfProtectMixin, FormView):
         )
         return super(PasswordResetView, self).form_valid(form)
 
-password_reset = PasswordResetView.as_view()
-friendly_password_reset = PasswordResetView.as_view(
-    form_class=FriendlyPasswordResetForm
-)
-
 
 class PasswordResetDoneView(TemplateView):
     template_name = 'registration/password_reset_done.html'
-
-password_reset_done = PasswordResetDoneView.as_view()
 
 
 class PasswordResetConfirmView(AuthDecoratorsMixin, FormView):
@@ -311,13 +291,6 @@ class PasswordResetConfirmView(AuthDecoratorsMixin, FormView):
         return form.save()
 
 
-password_reset_confirm = PasswordResetConfirmView.as_view()
-
-# Django 1.6 added this as a temporary shim, see #14881. Since our view
-# works with base 36 or base 64, we can use the same view for both.
-password_reset_confirm_uidb36 = PasswordResetConfirmView.as_view()
-
-
 class PasswordResetConfirmAndLoginView(PasswordResetConfirmView):
     success_url = resolve_url_lazy(settings.LOGIN_REDIRECT_URL)
 
@@ -327,8 +300,6 @@ class PasswordResetConfirmAndLoginView(PasswordResetConfirmView):
                                  password=form.cleaned_data['new_password1'])
         auth.login(self.request, user)
         return ret
-
-password_reset_confirm_and_login = PasswordResetConfirmAndLoginView.as_view()
 
 
 class PasswordResetCompleteView(TemplateView):
@@ -342,5 +313,3 @@ class PasswordResetCompleteView(TemplateView):
         kwargs = super(PasswordResetCompleteView, self).get_context_data(**kwargs)
         kwargs['login_url'] = self.get_login_url()
         return kwargs
-
-password_reset_complete = PasswordResetCompleteView.as_view()

--- a/authtools/views.py
+++ b/authtools/views.py
@@ -224,6 +224,7 @@ class PasswordResetView(CsrfProtectMixin, FormView):
     domain_override = None
     subject_template_name = 'registration/password_reset_subject.txt'
     email_template_name = 'registration/password_reset_email.html'
+    html_email_template_name = None
     from_email = None
     form_class = PasswordResetForm
 
@@ -236,6 +237,7 @@ class PasswordResetView(CsrfProtectMixin, FormView):
             from_email=self.from_email,
             request=self.request,
             use_https=self.request.is_secure(),
+            html_email_template_name=self.html_email_template_name,
         )
         return super(PasswordResetView, self).form_valid(form)
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/auth_tests/

--- a/tests/tests/fixtures/authtoolstestdata.json
+++ b/tests/tests/fixtures/authtoolstestdata.json
@@ -1,0 +1,99 @@
+[
+    {
+        "pk": "1",
+        "model": "authtools.user",
+        "fields": {
+            "name": "Test Client",
+            "name": "Test Client",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+            "email": "testclient@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "2",
+        "model": "authtools.user",
+        "fields": {
+            "name": "Inactive User",
+            "is_active": false,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+            "email": "testclient2@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "3",
+        "model": "authtools.user",
+        "fields": {
+            "name": "Staff Member",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": true,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+            "email": "staffmember@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "4",
+        "model": "authtools.user",
+        "fields": {
+            "name": "Empty Password",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "empty_password@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "5",
+        "model": "authtools.user",
+        "fields": {
+            "name": "Unmanageable Password",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "$",
+            "email": "unmanageable_password@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "6",
+        "model": "authtools.user",
+        "fields": {
+            "name": "Unknown Password",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "foo$bar",
+            "email": "unknown_password@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    }
+]

--- a/tests/tests/fixtures/customusertestdata.json
+++ b/tests/tests/fixtures/customusertestdata.json
@@ -1,0 +1,104 @@
+[
+    {
+        "pk": "1",
+        "model": "tests.user",
+        "fields": {
+            "full_name": "Test Client",
+            "preferred_name": "Test",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+            "email": "testclient@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "2",
+        "model": "tests.user",
+        "fields": {
+            "full_name": "Inactive User",
+            "preferred_name": "Inactive",
+            "is_active": false,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+            "email": "testclient2@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "3",
+        "model": "tests.user",
+        "fields": {
+            "full_name": "Staff Member",
+            "preferred_name": "Staff",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": true,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161",
+            "email": "staffmember@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "4",
+        "model": "tests.user",
+        "fields": {
+            "full_name": "Empty Password",
+            "preferred_name": "Empty",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "",
+            "email": "empty_password@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "5",
+        "model": "tests.user",
+        "fields": {
+            "full_name": "Unmanageable Password",
+            "preferred_name": "Unmanageable",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "$",
+            "email": "unmanageable_password@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    },
+    {
+        "pk": "6",
+        "model": "tests.user",
+        "fields": {
+            "full_name": "Unknown Password",
+            "preferred_name": "Unknown",
+            "is_active": true,
+            "is_superuser": false,
+            "is_staff": false,
+            "last_login": "2006-12-17 07:03:31",
+            "groups": [],
+            "user_permissions": [],
+            "password": "foo$bar",
+            "email": "unknown_password@example.com",
+            "date_joined": "2006-12-17 07:03:31"
+        }
+    }
+]

--- a/tests/tests/settings.py
+++ b/tests/tests/settings.py
@@ -14,6 +14,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'tests',
     'authtools',
+    'auth_tests',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -21,6 +22,8 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
 )
 
 DATABASES = {
@@ -46,3 +49,11 @@ DEBUG = True
 AUTH_USER_MODEL = os.environ.get('AUTH_USER_MODEL', 'auth.User')
 
 print('Using %s as the AUTH_USER_MODEL.' % AUTH_USER_MODEL)
+
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]

--- a/tests/tests/settings.py
+++ b/tests/tests/settings.py
@@ -38,7 +38,6 @@ DATABASES = {
 # (because these modules don't exist)
 MIGRATION_MODULES = {
     'auth': 'django.contrib.auth.tests.migrations',
-    'contenttypes': 'django.contrib.contenttypes.tests.migrations',
 }
 
 ROOT_URLCONF = 'tests.urls'

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -28,31 +28,16 @@ from django.conf import settings
 
 from authtools.views import LoginView
 
-try:
-    # Django 1.6
-    from django.contrib.auth.tests.test_views import (
-        AuthViewNamedURLTests,
-        PasswordResetTest,
-        ChangePasswordTest,
-        LoginTest,
-        LoginURLSettings,
-        LogoutTest,
-    )
-except ImportError:
-    # Django 1.5
-    from django.contrib.auth.tests.views import (
-        AuthViewNamedURLTests,
-        PasswordResetTest,
-        ChangePasswordTest,
-        LoginTest,
-        LoginURLSettings,
-        LogoutTest,
-    )
+from auth_tests.test_views import (
+    AuthViewNamedURLTests,
+    PasswordResetTest,
+    ChangePasswordTest,
+    LoginTest,
+    LoginURLSettings,
+    LogoutTest,
+)
 
-try:
-    from django.contrib.sites.shortcuts import get_current_site
-except ImportError:  # Django < 1.7
-    from django.contrib.sites.models import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 
 
 from authtools.admin import BASE_FIELDS

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -80,8 +80,9 @@ class WarningTestMixin(object):
                 assert issubclass(msg.category, expected_class)
 
 
+@override_settings(ROOT_URLCONF='authtools.urls')
 class AuthViewNamedURLTests(AuthViewNamedURLTests):
-    urls = 'authtools.urls'
+    pass
 
 
 class UtilsTest(TestCase):
@@ -89,8 +90,8 @@ class UtilsTest(TestCase):
         self.assertTrue(resolve_url_lazy(u'/'))
 
 
+@override_settings(ROOT_URLCONF='tests.urls')
 class PasswordResetTest(PasswordResetTest):
-    urls = 'tests.urls'
 
     # these use custom, test-specific urlpatterns that we don't have
     test_admin_reset = None
@@ -173,8 +174,8 @@ class PasswordResetTest(PasswordResetTest):
         self.assertEqual(response.status_code, 200)
 
 
+@override_settings(ROOT_URLCONF='authtools.urls')
 class ChangePasswordTest(ChangePasswordTest):
-    urls = 'authtools.urls'
 
     test_password_change_redirect_custom = None
     test_password_change_redirect_custom_named = None
@@ -193,8 +194,8 @@ class ChangePasswordTest(ChangePasswordTest):
         self.login(password='password1')
 
 
+@override_settings(ROOT_URLCONF='authtools.urls')
 class LoginTest(LoginTest):
-    urls = 'authtools.urls'
 
     # the built-in tests depend on the django urlpatterns (they reverse
     # django.contrib.auth.views.login)
@@ -270,12 +271,13 @@ class DeprecationTest(WarningTestMixin, TestCase):
 
 
 
+@override_settings(ROOT_URLCONF='tests.urls')
 class LoginURLSettings(LoginURLSettings):
-    urls = 'tests.urls'
+    pass
 
 
+@override_settings(ROOT_URLCONF='tests.urls')
 class LogoutTest(LogoutTest):
-    urls = 'tests.urls'
 
     test_logout_with_overridden_redirect_url = None
     test_logout_with_next_page_specified = None

--- a/tests/tests/urls.py
+++ b/tests/tests/urls.py
@@ -3,8 +3,9 @@ from django.conf.urls import patterns, include, url
 from django.http import HttpResponse
 from django.contrib.auth.decorators import login_required
 from django.contrib import admin
+from django.core.urlresolvers import reverse_lazy
 
-from authtools.views import PasswordResetView
+from authtools import views
 from authtools.forms import FriendlyPasswordResetForm
 
 admin.autodiscover()
@@ -14,22 +15,14 @@ def dumbview(request):
     return HttpResponse('dumbview')
 
 
-if django.VERSION < (1, 6):
-    urlpatterns = patterns('authtools.views',
-        url('^reset_and_login/(?P<uidb36>[0-9A-Za-z]{1,13})-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', 'password_reset_confirm_and_login'),
-    )
-else:
-    urlpatterns = patterns('authtools.views',
-        url(r'^reset_and_login/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', 'password_reset_confirm_and_login'),
-    )
-
-urlpatterns += patterns('',
-    url('^logout-then-login/$', 'authtools.views.logout_then_login', name='logout_then_login'),
-    url('^friendly_password_reset/$',
-        PasswordResetView.as_view(form_class=FriendlyPasswordResetForm),
+urlpatterns = [
+    url(r'^reset_and_login/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', views.PasswordResetConfirmAndLoginView.as_view()),
+    url(r'^logout-then-login/$', views.LogoutView.as_view(url=reverse_lazy('login')), name='logout_then_login'),
+    url(r'^friendly_password_reset/$',
+        views.PasswordResetView.as_view(form_class=FriendlyPasswordResetForm),
         name='friendly_password_reset'),
-    url('^login_required/$', login_required(dumbview), name='login_required'),
+    url(r'^login_required/$', login_required(dumbview), name='login_required'),
     # From django.contrib.auth.tests.url
-    url('^password_reset/html_email_template/$', 'django.contrib.auth.views.password_reset', dict(html_email_template_name='registration/html_password_reset_email.html')),
-    url('^', include('authtools.urls')),
-)
+    url(r'^password_reset/html_email_template/$', views.PasswordResetView.as_view(html_email_template_name='registration/html_password_reset_email.html')),
+    url(r'^', include('authtools.urls')),
+]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist=
 
 [testenv]
 basepython=
-  py26: python2.6
   py27: python2.7
   py33: python3.3
 commands=

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,33}-dj{17,18}
+    py{27,33}-dj18
 
 [testenv]
 basepython=
@@ -10,7 +10,6 @@ commands=
   /usr/bin/env
   make test
 deps=
-  dj17: Django>=1.7,<1.8
   dj18: Django>=1.8,<1.9
 whitelist_externals=
   env

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist=
-    py{26,27,33}-dj{15,16},
-    py{27,33}-dj{17}
+    py{27,33}-dj{17,18}
 
 [testenv]
 basepython=
@@ -12,10 +11,8 @@ commands=
   /usr/bin/env
   make test
 deps=
-  dj15,dj16: South>=1.0.2
-  dj15: Django>=1.5,<1.6
-  dj16: Django>=1.6,<1.7
   dj17: Django>=1.7,<1.8
+  dj18: Django>=1.8,<1.9
 whitelist_externals=
   env
   make


### PR DESCRIPTION
This will allow us to officially release django-authtools for Django 1.8 instead of installing from source.

Unfortunately, the tests are broken with a custom user models (mainly because of fixtures).