### PR TITLE
Update tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps=
   dj15: Django>=1.5,<1.6
   dj16: Django>=1.6,<1.7
   dj17: Django>=1.7,<1.8
+  dj18: Django>=1.8,<1.9
+  dj19: Django>=1.9,<1.10
 whitelist_externals=
   env
   make


### PR DESCRIPTION
Add tests for  Django 1.8 and 1.9 now that there's a stable 1.9 release.
