### PR TITLE
Get the password help text from Django

### DIFF
--- a/authtools/forms.py
+++ b/authtools/forms.py
@@ -3,7 +3,8 @@ from __future__ import unicode_literals
 from django import forms, VERSION as DJANGO_VERSION
 from django.contrib.auth.forms import (
     ReadOnlyPasswordHashField, ReadOnlyPasswordHashWidget,
-    PasswordResetForm as OldPasswordResetForm
+    PasswordResetForm as OldPasswordResetForm,
+    UserChangeForm as DjangoUserChangeForm,
 )
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import identify_hasher
@@ -151,10 +152,8 @@ class AdminUserChangeForm(UserChangeForm):
     def __init__(self, *args, **kwargs):
         super(AdminUserChangeForm, self).__init__(*args, **kwargs)
         if not self.fields['password'].help_text:
-            self.fields['password'].help_text = _(
-                "Raw passwords are not stored, so there is no way to see this"
-                " user's password, but you can change the password using"
-                " <a href=\"../password/\">this form</a>.")
+            self.fields['password'].help_text = \
+                DjangoUserChangeForm.base_fields['password'].help_text
 
 
 class FriendlyPasswordResetForm(OldPasswordResetForm):


### PR DESCRIPTION
Django 1.8 and 1.9 use a different link, so just copy it from Django instead of thinking about it. Fixes #62.