### PR TITLE
docs.forms: fix format error

### DIFF
--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -15,6 +15,7 @@ User model that follows the :class:`User class contract <django:django.contrib.a
     and ``User.REQUIRED_FIELDS``.
 
 .. class:: CaseInsensitiveEmailUserCreationForm
+
     This is the same form as ``UserCreationForm``, but with an added method, ``clean_username``
     which lowercases the username before saving. It is recommended that you use this form if you
     choose to use either the  ``CaseInsensitiveEmailBackendMixin`` or


### PR DESCRIPTION
As can be seen in the online docs, `CaseInsensitiveEmailUserCreationForm` description is formatted incorrectly. A blank line is necessary.

https://django-authtools.readthedocs.org/en/latest/forms.html#authtools.forms.BetterReadOnlyPasswordHashWidget