### PR TITLE
Fix for issue #72

### DIFF
--- a/authtools/forms.py
+++ b/authtools/forms.py
@@ -107,18 +107,28 @@ class UserCreationForm(forms.ModelForm):
         return user
 
 
-class CaseInsensitiveEmailUserCreationForm(UserCreationForm):
+class CaseInsensitiveUsernameFieldCreationForm(UserCreationForm):
     """
     This form is the same as UserCreationForm, except that usernames are lowercased before they
     are saved. This is to disallow the existence of email address usernames which differ only in
     case.
     """
-    def clean_username(self):
-        username = self.cleaned_data.get('username')
+    def clean_USERNAME_FIELD(self):
+        username = self.cleaned_data.get(User.USERNAME_FIELD)
         if username:
             username = username.lower()
 
         return username
+
+# set the correct clean method on the class so that child classes can override and call super()
+setattr(
+    CaseInsensitiveUsernameFieldCreationForm,
+    'clean_' + User.USERNAME_FIELD,
+    CaseInsensitiveUsernameFieldCreationForm.clean_USERNAME_FIELD
+)
+
+# alias for the old name for backwards-compatability
+CaseInsensitiveEmailUserCreationForm = CaseInsensitiveUsernameFieldCreationForm
 
 
 class UserChangeForm(forms.ModelForm):


### PR DESCRIPTION
Fixes #72 by making a generic clean_username method, and setting the correct method dynamically based on `User.USERNAME_FIELD`.

Also renames `CaseInsensitiveEmailUserCreationForm` to `CaseInsensitiveUsernameFieldCreationForm` while keeping the old name as an alias.