### PR TITLE
Fixed password change link in user change admin.

### DIFF
--- a/authtools/forms.py
+++ b/authtools/forms.py
@@ -158,7 +158,7 @@ class AdminUserChangeForm(UserChangeForm):
         super(AdminUserChangeForm, self).__init__(*args, **kwargs)
         if not self.fields['password'].help_text:
             self.fields['password'].help_text = \
-                DjangoUserChangeForm.base_fields['password'].help_text
+                DjangoUserChangeForm.base_fields['password'].help_text.format('../password/')
 
 
 class FriendlyPasswordResetForm(OldPasswordResetForm):

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -67,7 +67,7 @@ from authtools.forms import (
     FriendlyPasswordResetForm,
     CaseInsensitiveUsernameFieldCreationForm,
     CaseInsensitiveEmailUserCreationForm,
-)
+    AdminUserChangeForm)
 from authtools.views import PasswordResetCompleteView, resolve_url_lazy
 
 User = get_user_model()
@@ -754,6 +754,26 @@ class UserChangeFormTest(TestCase):
         form = UserChangeForm(instance=user)
 
         self.assertIn(_('*************'), form.as_table())
+
+
+@skipIfCustomUser
+class AdminUserChangeFormTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.u = User.objects.create(
+            password='sha1$6efc0$f93efe9fd7542f25a7be94871ea45aa95de57161',
+            last_login=datetime.datetime(2006, 12, 17, 7, 3, 31), is_superuser=False, username='testclient',
+            first_name='Test', last_name='Client', email='testclient@example.com', is_staff=False, is_active=True,
+            date_joined=datetime.datetime(2006, 12, 17, 7, 3, 31)
+        )
+
+    def test_password_reset_link(self):
+        user = User.objects.get(username='testclient')
+        form = AdminUserChangeForm(data={}, instance=user)
+        if DJANGO_VERSION[:2] < (1, 9):
+            assert 'href="password/"' in form.fields['password'].help_text
+        else:
+            assert 'href="../password/"' in form.fields['password'].help_text
 
 
 class UserAdminTest(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=
     py{27,35,36}-dj18,
     py{27,34,35,36}-dj110,
     py{27,34,35,36}-dj111
+    py{34,35,36}-dj20
 
 [testenv]
 basepython=
@@ -18,10 +19,13 @@ deps=
   dj19: Django>=1.9,<1.10
   dj110: Django>=1.10,<1.11
   dj111: Django>=1.11,<1.12
+  dj20: Django>=2.0
 setenv=
   # tox requires at least one non-conditional setenv entry
   # https://github.com/tornadoweb/tornado/blob/v4.3.0/tox.ini#L101-L102
   DUMMY=dummy
+  dj20: DJANGO_VERSION=2.0.2
+  dj20: DJANGO_CHECKSUM=dc3b61d054f1bced64628c62025d480f655303aea9f408e5996c339a543b45f0
   dj111: DJANGO_VERSION=1.11
   dj111: DJANGO_CHECKSUM=b6f3b864944276b4fd1d099952112696558f78b77b39188ac92b6c5e80152c30
   dj110: DJANGO_VERSION=1.10.7


### PR DESCRIPTION
This fixes issue #91 where the password change link in the admin user change view is broken. 

The issue is caused by this commit in Django. https://github.com/django/django/commit/c52ae33a0c0c0bbaa460607a8787e95fe983a2b9