### PR TITLE
Update broken link in intro.rst

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -60,7 +60,7 @@ authorization just *might* be a good idea.  I recommend you read these:
 -  `Williams, Master of the "Come From" <https://github.com/raganwald/homoiconic/blob/master/2011/11/COMEFROM.md>`_
 
 Also, please read this quote from the `Django documentation
-<https://docs.djangoproject.com/en/1.5/topics/auth/customizing/#specifying-a-custom-user-model>`_:
+<https://docs.djangoproject.com/en/2.1/topics/auth/customizing/#specifying-a-custom-user-model>`_:
 
 .. warning::
 


### PR DESCRIPTION
Updated broken link to the source of a quote from the Django documentation.
The link now points to the latest version of the Django docs.
The quote has not changed.