### PR TITLE
Update associated Django version number in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 django-authtools
 ================
 
-A custom user model app for Django 1.5+. It tries to stay true to the built-in
+A custom user model app for Django 1.8+. It tries to stay true to the built-in
 User model for the most part.  The main differences between authtools and
 django.contrib.auth are a User model with email as username and classed-based
 auth views.


### PR DESCRIPTION
Changed from 1.5+ to 1.8+, as per:
https://github.com/fusionbox/django-authtools/blob/master/CHANGES.rst#140-2015-11-02