### PR TITLE
Fix the new Django admin user edit form's password change button

### DIFF
--- a/authtools/forms.py
+++ b/authtools/forms.py
@@ -31,22 +31,12 @@ class BetterReadOnlyPasswordHashWidget(ReadOnlyPasswordHashWidget):
     """
     A ReadOnlyPasswordHashWidget that has a less intimidating output.
     """
-    def render(self, name, value, attrs=None, renderer=None):
-        final_attrs = flatatt(self.build_attrs(attrs or {}))
 
-        if not value or not is_password_usable(value):
-            summary = gettext("No password set.")
-        else:
-            try:
-                identify_hasher(value)
-            except ValueError:
-                summary = gettext("Invalid password format or unknown"
-                                   " hashing algorithm.")
-            else:
-                summary = gettext('*************')
-
-        return format_html('<div{attrs}><strong>{summary}</strong></div>',
-                           attrs=final_attrs, summary=summary)
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        if any(item.get('value') for item in context['summary']):
+            context['summary'] = [{'label': '*************'}]
+        return context
 
 
 class UserChangeForm(DjangoUserChangeForm):

--- a/authtools/forms.py
+++ b/authtools/forms.py
@@ -35,7 +35,7 @@ class BetterReadOnlyPasswordHashWidget(ReadOnlyPasswordHashWidget):
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         if any(item.get('value') for item in context['summary']):
-            context['summary'] = [{'label': '*************'}]
+            context['summary'] = [{'label': gettext('*************')}]
         return context
 
 

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -257,6 +257,7 @@ class UserChangeFormTest(TestCase):
         form = UserChangeForm(instance=user)
 
         self.assertIn(_('*************'), form.as_table())
+        self.assertIn('<a class="button"', form.as_table())
 
 
 class UserAdminTest(TestCase):

--- a/tests/tests/tests.py
+++ b/tests/tests/tests.py
@@ -2,6 +2,7 @@ import datetime
 
 from unittest import skipIf, skipUnless
 
+import django
 from django.core import mail
 
 from django.test import TestCase
@@ -257,7 +258,15 @@ class UserChangeFormTest(TestCase):
         form = UserChangeForm(instance=user)
 
         self.assertIn(_('*************'), form.as_table())
-        self.assertIn('<a class="button"', form.as_table())
+
+        version = django.VERSION[0]
+
+        if version < 4:
+            self.assertIn('<a href="../password/">', form.as_table())
+        elif version < 5:
+            self.assertIn('<a href="../../{0}/password/">'.format(user.id), form.as_table())
+        else:
+            self.assertIn('<a class="button" href="../password/">', form.as_table())
 
 
 class UserAdminTest(TestCase):


### PR DESCRIPTION
At some point in the recent past
(https://code.djangoproject.com/ticket/34977), Django changed the user edit form away from showing a link to the password change page, into a button.  This relied on a call to `get_context()`, which this custom password widget wasn't invoking.